### PR TITLE
PackageInfo.g: drop redundant Autoload, TestFile

### DIFF
--- a/classicpres/PackageInfo.g
+++ b/classicpres/PackageInfo.g
@@ -158,9 +158,6 @@ PackageDoc := rec(
   # a longer title of the book, this together with the book name should
   # fit on a single text line (appears with the '?books' command in GAP)
   LongTitle := "Classical Group Presentations",
-  # Should this help book be autoloaded when GAP starts up? This should
-  # usually be 'true', otherwise say 'false'. 
-  Autoload := true
 ),
 
 
@@ -192,19 +189,11 @@ AvailabilityTest := ReturnTrue,
 
 TestFile := "tst/testall.g",
 
-##  Suggest here if the package should be *automatically loaded* when GAP is 
-##  started.  This should usually be 'false'. Say 'true' only if your package 
-##  provides some improvements of the GAP library which are likely to enhance 
-##  the overall system performance for many users.
-Autoload := true,
-
 ##  If the default banner does not suffice then provide a string that is
 ##  printed when the package is loaded (not when it is autoloaded or if
 ##  command line options `-b' or `-q' are given).
 BannerString := Concatenation("Classical Group Presentations, v.",
   ~.Version,"\n"),
-
-TestFile := "tst/testall.g",
 
 ##  *Optional*: Here you can list some keyword related to the topic 
 ##  of the package.


### PR DESCRIPTION
The TestFile entry was redundant because the same value is already set a few lines earlier.

Autoload for GAP packages and manuals hasn't been under the control of PackageInfo.g files for several years now.